### PR TITLE
Fix issue #13

### DIFF
--- a/src/Geometry/Geometry.jl
+++ b/src/Geometry/Geometry.jl
@@ -54,8 +54,6 @@ export
     skeleton,
     internal_boundary,
     external_boundary,
-    low_corner,
-    high_corner,
     measure,
     vertices,
     line,

--- a/src/Mesh/cartesianmesh.jl
+++ b/src/Mesh/cartesianmesh.jl
@@ -8,7 +8,7 @@ Iterating over a `UniformCartesianMesh` generates the elements which compose the
 i.e. the `HyperRectangle` cells.
 """
 struct UniformCartesianMesh{N,T} <: AbstractMesh{N,T}
-    domain::HyperRectangle{N,T}  # stores the `low_corner` and `high_corner` of the `UniformCartesianMesh`
+    domain::HyperRectangle{N,T}  # stores the `low_corner` and the `high_corner` of the `UniformCartesianMesh`
     sz::NTuple{N,Int}            # number of `HyperRectangle` cells per dimension
 end
 
@@ -39,7 +39,7 @@ function Base.step(m::UniformCartesianMesh{N}) where N
     lc = low_corner(m)
     hc = high_corner(m)
     sz = size(m)
-    return ntuple(N) do 
+    return ntuple(N) do i 
         (hc[i]-lc[i])/sz[i]
     end     
 end
@@ -77,11 +77,9 @@ end
 
 ambient_dimension(::UniformCartesianMesh{N}) where {N} = N
 
-xgrid(g::UniformCartesianMesh) = grids(g)[1]
-
-ygrid(g::UniformCartesianMesh) = grids(g)[2]
-
-zgrid(g::UniformCartesianMesh) = grids(g)[3]
+xgrid(g::UniformCartesianMesh) = grids(g,1)
+ygrid(g::UniformCartesianMesh) = grids(g,2)
+zgrid(g::UniformCartesianMesh) = grids(g,3)
 
 # implement ElementIterator interface to UniformCartesianMesh
 

--- a/src/Mesh/cartesianmesh.jl
+++ b/src/Mesh/cartesianmesh.jl
@@ -2,21 +2,47 @@
     struct UniformCartesianMesh{N,T} <: AbstractMesh{N,T}
 
 An `N`-dimensional cartesian grid given as the tensor-product of `N`
-one-dimensional `LinRange{T,Int}` grids.
+one-dimensional `LinRange{T}` grids. 
 
 Iterating over a `UniformCartesianMesh` generates the elements which compose the mesh;
 i.e. the `HyperRectangle` cells.
 """
 struct UniformCartesianMesh{N,T} <: AbstractMesh{N,T}
-    grids::NTuple{N,LinRange{T,Int}}
+    domain::HyperRectangle{N,T}  # stores the `low_corner` and `high_corner` of the `UniformCartesianMesh`
+    sz::NTuple{N,Int}            # number of `HyperRectangle` cells per dimension
 end
 
-grids(g::UniformCartesianMesh)     = g.grids
-grids(g::UniformCartesianMesh,dim) = g.grids[dim]
+Interpolation.low_corner(g::UniformCartesianMesh)  = low_corner(g.domain)
+Interpolation.high_corner(g::UniformCartesianMesh) = high_corner(g.domain)
 
-Base.keys(m::UniformCartesianMesh{N,T}) where {N,T} = (HyperRectangle{N,T},)
+Base.size(g::UniformCartesianMesh)   = g.sz
+Base.size(g::UniformCartesianMesh,i) = g.sz[i]
 
-Base.step(m::UniformCartesianMesh) = step.(grids(m))
+function grids(g::UniformCartesianMesh{N}) where N
+    lc = low_corner(g)
+    hc = high_corner(g)
+    len = size(g) .+ 1   # need n+1 points for n cells
+    return ntuple(N) do i
+        LinRange(lc[i],hc[i],len[i])
+    end
+end
+function grids(g::UniformCartesianMesh,dim)
+    start = low_corner(g)[dim]
+    stop = high_corner(g)[dim]
+    len = size(g,dim) + 1   # need n+1 points for n cells
+    return LinRange(start,stop,len)
+end
+
+Base.keys(::UniformCartesianMesh{N,T}) where {N,T} = (HyperRectangle{N,T},)
+
+function Base.step(m::UniformCartesianMesh{N}) where N
+    lc = low_corner(m)
+    hc = high_corner(m)
+    sz = size(m)
+    return ntuple(N) do 
+        (hc[i]-lc[i])/sz[i]
+    end     
+end
 
 """
     UniformCartesianMesh(domain::HyperRectangle,sz::NTuple)
@@ -26,17 +52,15 @@ Construct a uniform `UniformCartesianMesh` with `sz[d]` elements along dimension
 `d`. If the kwarg `step` is passed, construct a `UniformCartesianMesh` with
 elements of approximate size `step`.
 """
-function UniformCartesianMesh(domain::HyperRectangle{N,T},sz::NTuple{N}) where {N,T}
-    lc = low_corner(domain)
-    uc = high_corner(domain)
-    grids1d = ntuple(N) do n
-        # to have sz elements, need sz+1 points in LinRange.
-        npts = sz[n] + 1
-        LinRange{float(T),Int}(lc[n], uc[n], npts) # use float(T) in case T<:Integer
-    end
-    UniformCartesianMesh(grids1d)
-end
 UniformCartesianMesh(domain::HyperRectangle{N,T},sz::Int) where {N,T} = UniformCartesianMesh(domain,ntuple(i->sz,N))
+
+function UniformCartesianMesh(grids::NTuple{N,LinRange{T}}) where {N,T}
+    lc = SVector{N,T}(minimum(r) for r in grids)
+    hc = SVector{N,T}(maximum(r) for r in grids)
+    sz = length.(grids) .- 1   # need n+1 points for n cells
+    domain = HyperRectangle(lc,hc)
+    return UniformCartesianMesh(domain,sz)
+end
 
 # in case you pass arguments like UniformCartesianMesh(xgrid,ygrid), convert
 # them to a Tuple
@@ -48,22 +72,22 @@ function UniformCartesianMesh(domain::HyperRectangle{N};step::NTuple{N}) where {
     sz = ntuple(N) do i
         (hc[i] - lc[i]) / step[i] |> ceil |> Int
     end
-    UniformCartesianMesh(domain,sz)
+    return UniformCartesianMesh(domain,sz)
 end
 
-ambient_dimension(g::UniformCartesianMesh{N}) where {N} = N
+ambient_dimension(::UniformCartesianMesh{N}) where {N} = N
 
-xgrid(g::UniformCartesianMesh) = g.grids[1]
+xgrid(g::UniformCartesianMesh) = grids(g)[1]
 
-ygrid(g::UniformCartesianMesh) = g.grids[2]
+ygrid(g::UniformCartesianMesh) = grids(g)[2]
 
-zgrid(g::UniformCartesianMesh) = g.grids[3]
+zgrid(g::UniformCartesianMesh) = grids(g)[3]
 
 # implement ElementIterator interface to UniformCartesianMesh
 
 function Base.size(iter::ElementIterator{<:HyperRectangle,<:UniformCartesianMesh})
     g = mesh(iter)
-    length.(g.grids) .- 1
+    return size(g)
 end
 
 Base.length(iter::ElementIterator{<:HyperRectangle,<:UniformCartesianMesh}) = prod(size(iter))
@@ -76,71 +100,73 @@ function Base.getindex(iter::ElementIterator{<:HyperRectangle,<:UniformCartesian
     m = mesh(iter)
     N = ambient_dimension(m)
     @assert N == length(I)
+    _grids = grids(m)
     lc = ntuple(N) do dim
         i = I[dim]
-        m.grids[dim][i]
+        _grids[dim][i]
     end
     hc = ntuple(N) do dim
         i = I[dim] + 1
-        m.grids[dim][i]
+        _grids[dim][i]
     end
-    HyperRectangle(lc, hc)
+    return HyperRectangle(lc, hc)
 end
 function Base.getindex(iter::ElementIterator{<:HyperRectangle,<:UniformCartesianMesh},I...)
-    iter[CartesianIndex(I)]
+    return iter[CartesianIndex(I)]
 end
 function Base.getindex(iter::ElementIterator{<:HyperRectangle,<:UniformCartesianMesh}, i::Int)
     I = CartesianIndices(iter)
-    iter[I[i]]
+    return iter[I[i]]
 end
 
 function Base.iterate(iter::ElementIterator{<:HyperRectangle,<:UniformCartesianMesh},state=1)
     state > length(iter) && (return nothing)
-    iter[state], state + 1
+    return iter[state], state + 1
 end
 
 # since UniformCartesianMesh has only one elment type, calling ElementIterator without
 # specifying the has clear sense
 function ElementIterator(m::UniformCartesianMesh)
     E = keys(m) |> first
-    ElementIterator(m,E)
+    return ElementIterator(m,E)
 end
 
 # NodeIterator over UniformCartesianMesh
 
-function Base.IteratorSize(iter::Type{NodeIterator{UniformCartesianMesh{N,T}}}) where {N,T}
-    Base.HasShape{N}()
+function Base.IteratorSize(::Type{NodeIterator{UniformCartesianMesh{N,T}}}) where {N,T}
+    return Base.HasShape{N}()
 end
 
 function Base.size(iter::NodeIterator{<:UniformCartesianMesh})
     g = mesh(iter)
-    length.(g.grids)
+    return size(g) .+ 1   # need n+1 points for n cells
 end
 
 Base.length(iter::NodeIterator{<:UniformCartesianMesh}) = prod(size(iter))
 
 function Base.CartesianIndices(iter::NodeIterator{<:UniformCartesianMesh})
-    CartesianIndices(size(iter))
+    return CartesianIndices(size(iter))
 end
 
 function Base.getindex(iter::NodeIterator{<:UniformCartesianMesh}, I::CartesianIndex)
     m = mesh(iter)
     N = ambient_dimension(m)
     @assert N == length(I)
-    svector(N) do dim
+    _grids = grids(m)
+    return svector(N) do dim
         i = I[dim]
-        m.grids[dim][i]
+        _grids[dim][i]
     end
 end
 function Base.getindex(iter::NodeIterator{<:UniformCartesianMesh},I...)
-    iter[CartesianIndex(I)]
+    return iter[CartesianIndex(I)]
 end
 function Base.getindex(iter::NodeIterator{<:UniformCartesianMesh}, i::Int)
     I = CartesianIndices(iter)
-    iter[I[i]]
+    return iter[I[i]]
 end
 
 function Base.iterate(iter::NodeIterator{<:UniformCartesianMesh},state=1)
     state > length(iter) && (return nothing)
-    iter[state], state + 1
+    return iter[state], state + 1
 end

--- a/test/Mesh/cartesianmesh_test.jl
+++ b/test/Mesh/cartesianmesh_test.jl
@@ -11,6 +11,9 @@ using StaticArrays
     h = 0.1 # grid spacing
     mesh = UniformCartesianMesh(l,(10,))
     @test mesh == UniformCartesianMesh(l,10)
+    @test mesh == UniformCartesianMesh(grids(mesh)) == UniformCartesianMesh(grids(mesh)...)
+    @test mesh == UniformCartesianMesh(l; step=step(mesh))
+    @test Mesh.xgrid(mesh) == LinRange(0.,1.,11)
     @test keys(mesh) == (E,)
     iter = ElementIterator(mesh,E)
     @test eltype(iter) == E
@@ -32,6 +35,10 @@ end
     E    = typeof(l) # type of mesh element
     mesh = UniformCartesianMesh(l,(10,20))
     iter = ElementIterator(mesh,E)
+    @test mesh == UniformCartesianMesh(grids(mesh)) == UniformCartesianMesh(grids(mesh)...)
+    @test mesh == UniformCartesianMesh(l; step=step(mesh))
+    @test Mesh.xgrid(mesh) == LinRange(0.,1.,11)
+    @test Mesh.ygrid(mesh) == LinRange(0.,1.,21)
     @test iter[1,1] ≈ HyperRectangle((0,0),(0.1,0.05))
     @test length(iter) == 200
     @test size(iter) == (10,20)

--- a/test/Mesh/cartesianmesh_test.jl
+++ b/test/Mesh/cartesianmesh_test.jl
@@ -10,6 +10,7 @@ using StaticArrays
     E = typeof(l) # type of mesh element
     h = 0.1 # grid spacing
     mesh = UniformCartesianMesh(l,(10,))
+    @test mesh == UniformCartesianMesh(l,10)
     @test keys(mesh) == (E,)
     iter = ElementIterator(mesh,E)
     @test eltype(iter) == E
@@ -34,8 +35,19 @@ end
     @test iter[1,1] ≈ HyperRectangle((0,0),(0.1,0.05))
     @test length(iter) == 200
     @test size(iter) == (10,20)
+    for I in CartesianIndices(iter)
+        i,j = Tuple(I)
+        el = iter[i,j]
+        @test el ≈ HyperRectangle(((i-1)*0.1,(j-1)*0.05),(i*0.1,j*0.05))
+    end
+
     iter = NodeIterator(mesh)
     @test eltype(iter) == SVector{2,Float64}
     @test length(iter) == 11*21
     @test size(iter) == (11,21)
+    for I in CartesianIndices(iter)
+        i,j = Tuple(I)
+        el = iter[i,j]
+        @test el ≈ SVector((i-1)*0.1,(j-1)*0.05)
+    end
 end


### PR DESCRIPTION
Fixes issue #13.
`UniformCartesianMesh` now stores a `HyperRectangle` and the number of cells per dimension, instead of a `LinRange` tuple. Some `UniformCartesianMesh` tests were also added. 
I checked that `UniformCartesianMesh`'s methods were type-stable in Julia 1.6, but I haven't done the test in Julia 1.7.